### PR TITLE
Add problem 1929 solve and example implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
+mod problem_1929;
 mod problem_2235;

--- a/src/problem_1929.rs
+++ b/src/problem_1929.rs
@@ -1,0 +1,24 @@
+fn solve(nums: &[i32]) -> Vec<i32> {
+    [nums, nums].concat()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn example_1() {
+        let nums = [1, 2, 1];
+        let expected_output = [1, 2, 1, 1, 2, 1];
+        let output = solve(&nums);
+        assert_eq!(output, expected_output);
+    }
+
+    #[test]
+    fn example_2() {
+        let nums = [1, 3, 2, 1];
+        let expected_output = [1, 3, 2, 1, 1, 3, 2, 1];
+        let output = solve(&nums);
+        assert_eq!(output, expected_output);
+    }
+}


### PR DESCRIPTION
- Added `problem_1929` module.
- Added `fn solve()` function in this module.
- Added test cases for examples in this module. e.g.) `fn example_1()`

![image](https://github.com/user-attachments/assets/20b383d7-1df8-4aca-8556-abec0e8d1ce9)
